### PR TITLE
Bug fix for AD case insensitivity

### DIFF
--- a/django_auth_ldap3/backends.py
+++ b/django_auth_ldap3/backends.py
@@ -53,6 +53,9 @@ class LDAPBackend(object):
         time the user has authenticated.
         """
 
+        #Force username to lower for Active Directory
+        username = username.lower()
+
         # Authenticate against the LDAP backend and return an LDAPUser.
         ldap_user = self.retrieve_ldap_user(username, password)
         if ldap_user is None:


### PR DESCRIPTION
Forced username to lower because AD is case insensitive.  Django will create new users otherwise.
