### PR TITLE
Add LDAP->Django Group mapping

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@
 * Sam Kingston <sam@sjkwi.com.au>
 * @gianlo
 * Ryan Massoth (@rmassoth)
+* Alan D Moore (@alandmoore)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A full configuration reference of all settings [is available](https://github.com
    URI](https://www.centos.org/docs/5/html/CDS/ag/8.0/LDAP_URLs-Examples_of_LDAP_URLs.html)
    is allowed for the `AUTH_LDAP_URI` setting (the port is optional and will
    default to 389 if not specified). TLS is not yet supported (see [issue #3](https://github.com/sjkingo/django_auth_ldap3/issues/3)).
-   
+
    * `AUTH_LDAP_BASE_DN` must be set to the base container to perform any subtree
    searches from.
 
@@ -133,6 +133,22 @@ example:
 ```
 AUTH_LDAP_ADMIN_GROUP = 'cn=Admin Users,ou=Groups,dc=example,dc=com'
 ```
+
+Should you wish to map LDAP groups to Django groups, you can use the `AUTH_LDAP_GROUP_MAP`
+setting.  By default it is set to `None`, indicating that no mapping will occur.  The mapping is
+done in the form of a dict where the keys are LDAP group DNs and the values are sequences of Django groups,
+for example:
+
+```
+AUTH_LDAP_GROUP_MAP = {
+    'cn=Admin Users,ou=Groups,dc=example,dc=com': ('site_admins', 'editors'),
+    'cn=Authors,ou=Groups,dc=example,dc=com': ('editors',)
+}
+```
+
+Note that any Django groups you list will be controlled by this mapping, and can't be manually managed,
+because users will be added or removed from the groups according to their LDAP group memberships at login.
+Any Django groups not included in the mappings will be unaffected.
 
 ## Example configuration for OpenLDAP
 

--- a/django_auth_ldap3/backends.py
+++ b/django_auth_ldap3/backends.py
@@ -253,7 +253,7 @@ class LDAPBackend(object):
             else:
                 groups['remove'] += [group for group in django_groups if group not in groups['remove']]
 
-        for operation in ('add', 'remove'):
+        for operation in ('remove', 'add'):
             grouplist = groups[operation]
             for group in grouplist:
                 try:

--- a/django_auth_ldap3/backends.py
+++ b/django_auth_ldap3/backends.py
@@ -1,10 +1,13 @@
 from django_auth_ldap3.conf import settings
 
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
 from ldap3.core.exceptions import LDAPSocketOpenError
 import hashlib
 import ldap3
 import logging
+
+User = get_user_model()
 
 logger = logging.getLogger('django_auth_ldap3')
 

--- a/django_auth_ldap3/conf.py
+++ b/django_auth_ldap3/conf.py
@@ -14,6 +14,7 @@ class LDAPSettings(object):
         'ADMIN_GROUP': None,
         'BASE_DN': 'dc=example,dc=com',
         'BIND_TEMPLATE': 'uid={username},{base_dn}',
+        'GROUP_MAP': None,
         'LOGIN_GROUP': '*',
         'UID_ATTRIB': 'uid',
         'USERNAME_PREFIX': None,


### PR DESCRIPTION
This PR addresses issue #11 by adding a GROUP_MAP setting which allows an LDAP group to be mapped to a list of Django groups. The listed groups will be added or removed from a user's account at login time based on the users membership or non-membership in the LDAP group.
