### PR TITLE
Default empty attribs to empty string

### DIFF
--- a/django_auth_ldap3/backends.py
+++ b/django_auth_ldap3/backends.py
@@ -31,7 +31,7 @@ class LDAPUser(object):
         # Set any missing attributes
         for k in self._attrib_keys:
             if not hasattr(self, k):
-                setattr(self, k, None)
+                setattr(self, k, '')
 
     def __str__(self):
         return self.username


### PR DESCRIPTION
When LDAP has empty values for an attribute, default to an empty string
rather than None.  This fixes issue #19.
